### PR TITLE
fix: Instances reuse runtime signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updating the `runtime.New` function to accept a `signature.New` factory function (`runtime.NewSignature`) instead of a `signature.Signature` type. 
 - Updated `runtime_test.go` to use the new `runtime.New` function signature.
 - Updated the `runtime.Instance` function to make the `next` argument optional. 
+- `instance.RuntimeContext` is now a private function since we don't expect developers to use it directly.
 
 ## [v0.1.1] - 2022-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changes 
+
+- Added `runtime.NewSignature` type to signify a factory function for creating a new `signature.Signature` type.
+- Updating the `runtime.New` function to accept a `signature.New` factory function (`runtime.NewSignature`) instead of a `signature.Signature` type. 
+- Updated `runtime_test.go` to use the new `runtime.New` function signature.
+- Updated the `runtime.Instance` function to make the `next` argument optional. 
+
 ## [v0.1.1] - 2022-11-28
 
 ### Changes

--- a/go/function.go
+++ b/go/function.go
@@ -45,7 +45,7 @@ func (f *Function[T]) Run(ctx context.Context, i *Instance[T]) error {
 		f.modulePool.Put(module)
 	}()
 
-	ctxBuffer := i.RuntimeContext().Write()
+	ctxBuffer := i.runtimeContext().Write()
 	ctxBufferLength := uint64(len(ctxBuffer))
 	writeBuffer, err := module.resize.Call(ctx, ctxBufferLength)
 	if err != nil {
@@ -70,7 +70,7 @@ func (f *Function[T]) Run(ctx context.Context, i *Instance[T]) error {
 		return fmt.Errorf("failed to read memory for function '%s'", f.scaleFunc.Name)
 	}
 
-	err = i.RuntimeContext().Read(readBuffer)
+	err = i.runtimeContext().Read(readBuffer)
 	if err != nil {
 		return fmt.Errorf("failed to deserialize context for function '%s': %w", f.scaleFunc.Name, err)
 	}

--- a/go/instance.go
+++ b/go/instance.go
@@ -29,15 +29,17 @@ type Instance[T signature.Signature] struct {
 	runtimeCtx signature.RuntimeContext
 }
 
-func (r *Runtime[T]) Instance(next Next[T]) (*Instance[T], error) {
+func (r *Runtime[T]) Instance(next ...Next[T]) (*Instance[T], error) {
+	ctx := r.new()
 	i := &Instance[T]{
-		next:       next,
 		runtime:    r,
-		ctx:        r.signature,
-		runtimeCtx: r.signature.RuntimeContext(),
+		ctx:        ctx,
+		runtimeCtx: ctx.RuntimeContext(),
 	}
 
-	if i.next == nil {
+	if len(next) > 0 {
+		i.next = next[0]
+	} else {
 		i.next = func(ctx T) (T, error) {
 			return ctx, nil
 		}
@@ -50,7 +52,7 @@ func (i *Instance[T]) Context() T {
 	return i.ctx
 }
 
-func (i *Instance[T]) RuntimeContext() signature.RuntimeContext {
+func (i *Instance[T]) runtimeContext() signature.RuntimeContext {
 	return i.runtimeCtx
 }
 

--- a/go/next.go
+++ b/go/next.go
@@ -37,7 +37,7 @@ func (r *Runtime[T]) next(ctx context.Context, module api.Module, params []uint6
 		return
 	}
 
-	err := m.instance.RuntimeContext().Read(buf)
+	err := m.instance.runtimeContext().Read(buf)
 	if err != nil {
 		return
 	}
@@ -46,16 +46,16 @@ func (r *Runtime[T]) next(ctx context.Context, module api.Module, params []uint6
 	if m.function.next == nil {
 		m.instance.ctx, err = m.instance.next(m.instance.Context())
 		if err != nil {
-			ctxBuffer = m.instance.RuntimeContext().Error(err)
+			ctxBuffer = m.instance.runtimeContext().Error(err)
 		} else {
-			ctxBuffer = m.instance.RuntimeContext().Write()
+			ctxBuffer = m.instance.runtimeContext().Write()
 		}
 	} else {
 		err = m.function.next.Run(ctx, m.instance)
 		if err != nil {
-			ctxBuffer = m.instance.RuntimeContext().Error(err)
+			ctxBuffer = m.instance.runtimeContext().Error(err)
 		} else {
-			ctxBuffer = m.instance.RuntimeContext().Write()
+			ctxBuffer = m.instance.runtimeContext().Write()
 		}
 	}
 

--- a/go/runtime.go
+++ b/go/runtime.go
@@ -38,13 +38,15 @@ var (
 // by whatever adapter is being used.
 type Next[T signature.Signature] func(ctx T) (T, error)
 
+type NewSignature[T signature.Signature] func() T
+
 // Runtime is the Scale Runtime. It is responsible for initializing
 // and managing the WASM runtime as well as the scale function chain.
 type Runtime[T signature.Signature] struct {
 	runtime      wazero.Runtime
 	moduleConfig wazero.ModuleConfig
 
-	signature T
+	new NewSignature[T]
 
 	functions []*Function[T]
 	head      *Function[T]
@@ -54,7 +56,7 @@ type Runtime[T signature.Signature] struct {
 	modules   map[string]*Module[T]
 }
 
-func New[T signature.Signature](ctx context.Context, sig T, functions []*scalefunc.ScaleFunc) (*Runtime[T], error) {
+func New[T signature.Signature](ctx context.Context, sig NewSignature[T], functions []*scalefunc.ScaleFunc) (*Runtime[T], error) {
 	if len(functions) == 0 {
 		return nil, NoFunctionsError
 	}
@@ -63,7 +65,7 @@ func New[T signature.Signature](ctx context.Context, sig T, functions []*scalefu
 		runtime:      wazero.NewRuntime(ctx),
 		moduleConfig: wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader),
 		modules:      make(map[string]*Module[T]),
-		signature:    sig,
+		new:          sig,
 	}
 
 	module := r.runtime.NewHostModuleBuilder("env").

--- a/go/runtime.go
+++ b/go/runtime.go
@@ -38,6 +38,7 @@ var (
 // by whatever adapter is being used.
 type Next[T signature.Signature] func(ctx T) (T, error)
 
+// NewSignature is a factory function for creating a new signature.Signature.
 type NewSignature[T signature.Signature] func() T
 
 // Runtime is the Scale Runtime. It is responsible for initializing

--- a/go/runtime_test.go
+++ b/go/runtime_test.go
@@ -83,10 +83,10 @@ func TestRuntime(t *testing.T) {
 			Name:   "Passthrough",
 			Module: passthroughModule,
 			Run: func(scaleFunc *scalefunc.ScaleFunc, t *testing.T) {
-				r, err := New(context.Background(), signature.New(), []*scalefunc.ScaleFunc{scaleFunc})
+				r, err := New(context.Background(), signature.New, []*scalefunc.ScaleFunc{scaleFunc})
 				require.NoError(t, err)
 
-				i, err := r.Instance(nil)
+				i, err := r.Instance()
 				require.NoError(t, err)
 
 				i.Context().Data = "Test Data"
@@ -106,7 +106,7 @@ func TestRuntime(t *testing.T) {
 					return ctx, nil
 				}
 
-				r, err := New(context.Background(), signature.New(), []*scalefunc.ScaleFunc{scaleFunc})
+				r, err := New(context.Background(), signature.New, []*scalefunc.ScaleFunc{scaleFunc})
 				require.NoError(t, err)
 
 				i, err := r.Instance(next)
@@ -128,7 +128,7 @@ func TestRuntime(t *testing.T) {
 					return nil, errors.New("next error")
 				}
 
-				r, err := New(context.Background(), signature.New(), []*scalefunc.ScaleFunc{scaleFunc})
+				r, err := New(context.Background(), signature.New, []*scalefunc.ScaleFunc{scaleFunc})
 				require.NoError(t, err)
 
 				i, err := r.Instance(next)
@@ -142,7 +142,7 @@ func TestRuntime(t *testing.T) {
 			Name:   "File",
 			Module: fileModule,
 			Run: func(scaleFunc *scalefunc.ScaleFunc, t *testing.T) {
-				r, err := New(context.Background(), signature.New(), []*scalefunc.ScaleFunc{scaleFunc})
+				r, err := New(context.Background(), signature.New, []*scalefunc.ScaleFunc{scaleFunc})
 				require.NoError(t, err)
 
 				i, err := r.Instance(nil)
@@ -156,7 +156,7 @@ func TestRuntime(t *testing.T) {
 			Name:   "Network",
 			Module: networkModule,
 			Run: func(scaleFunc *scalefunc.ScaleFunc, t *testing.T) {
-				r, err := New(context.Background(), signature.New(), []*scalefunc.ScaleFunc{scaleFunc})
+				r, err := New(context.Background(), signature.New, []*scalefunc.ScaleFunc{scaleFunc})
 				require.NoError(t, err)
 
 				i, err := r.Instance(nil)
@@ -170,7 +170,7 @@ func TestRuntime(t *testing.T) {
 			Name:   "Panic",
 			Module: panicModule,
 			Run: func(scaleFunc *scalefunc.ScaleFunc, t *testing.T) {
-				r, err := New(context.Background(), signature.New(), []*scalefunc.ScaleFunc{scaleFunc})
+				r, err := New(context.Background(), signature.New, []*scalefunc.ScaleFunc{scaleFunc})
 				require.NoError(t, err)
 
 				i, err := r.Instance(nil)
@@ -184,7 +184,7 @@ func TestRuntime(t *testing.T) {
 			Name:   "BadSignature",
 			Module: badSignatureModule,
 			Run: func(scaleFunc *scalefunc.ScaleFunc, t *testing.T) {
-				r, err := New(context.Background(), signature.New(), []*scalefunc.ScaleFunc{scaleFunc})
+				r, err := New(context.Background(), signature.New, []*scalefunc.ScaleFunc{scaleFunc})
 				require.NoError(t, err)
 
 				i, err := r.Instance(nil)


### PR DESCRIPTION
Currently, the signature being used in the runtime that is passed into `runtime.New` gets reused across all instances. 

This PR fixes that. 