### PR TITLE
Fix: Remove locking to reference bare global instead

### DIFF
--- a/rust/compile/templates/lib.rs.templ
+++ b/rust/compile/templates/lib.rs.templ
@@ -48,9 +48,9 @@ pub unsafe extern "C" fn run() -> u64 {
 #[cfg_attr(all(target_arch = "wasm32"), export_name = "resize")]
 #[no_mangle]
 pub unsafe extern "C" fn resize(size: u32) -> *const u8 {
-   let existing_cap = READ_BUFFER.lock().unwrap().capacity() as u32;
-   READ_BUFFER.lock().unwrap().reserve_exact((size - existing_cap) as usize);
-   let ptr = READ_BUFFER.lock().unwrap().as_ptr();
+   let existing_cap = READ_BUFFER.capacity() as u32;
+   READ_BUFFER.reserve_exact((size - existing_cap) as usize);
+   let ptr = READ_BUFFER.as_ptr();
 
    *PTR.lock().unwrap() = ptr as u32;
    *LEN.lock().unwrap() = size;


### PR DESCRIPTION
Closes: https://linear.app/loopholelabs/issue/LOOP-58/rust-mutex-blocks-on-globals-only-causes-problems-with-next-functions