### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/loopholelabs/scale-signature v0.1.1
 	github.com/loopholelabs/scalefile v0.1.0
 	github.com/stretchr/testify v1.8.1
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/yalue/merged_fs v1.2.2 h1:vXHTpJBluJryju7BBpytr3PDIkzsPMpiEknxVGPhN/I=
 github.com/yalue/merged_fs v1.2.2/go.mod h1:WqqchfVYQyclV2tnR7wtRhBddzBvLVR83Cjw9BKQw0M=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/go/function.go
+++ b/go/function.go
@@ -19,6 +19,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+
 	signature "github.com/loopholelabs/scale-signature"
 	"github.com/loopholelabs/scale/go/utils"
 	"github.com/loopholelabs/scalefile/scalefunc"
@@ -52,7 +53,7 @@ func (f *Function[T]) Run(ctx context.Context, i *Instance[T]) error {
 		return fmt.Errorf("failed to allocate memory for function '%s': %w", f.scaleFunc.Name, err)
 	}
 
-	if !module.module.Memory().Write(ctx, uint32(writeBuffer[0]), ctxBuffer) {
+	if !module.module.Memory().Write(uint32(writeBuffer[0]), ctxBuffer) {
 		return fmt.Errorf("failed to write memory for function '%s'", f.scaleFunc.Name)
 	}
 
@@ -65,7 +66,7 @@ func (f *Function[T]) Run(ctx context.Context, i *Instance[T]) error {
 	}
 
 	offset, length := utils.UnpackUint32(packed[0])
-	readBuffer, ok := module.module.Memory().Read(ctx, offset, length)
+	readBuffer, ok := module.module.Memory().Read(offset, length)
 	if !ok {
 		return fmt.Errorf("failed to read memory for function '%s'", f.scaleFunc.Name)
 	}

--- a/go/next.go
+++ b/go/next.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"context"
+
 	"github.com/tetratelabs/wazero/api"
 )
 
@@ -32,7 +33,7 @@ func (r *Runtime[T]) next(ctx context.Context, module api.Module, params []uint6
 		return
 	}
 
-	buf, ok := m.module.Memory().Read(ctx, pointer, length)
+	buf, ok := m.module.Memory().Read(pointer, length)
 	if !ok {
 		return
 	}
@@ -64,7 +65,7 @@ func (r *Runtime[T]) next(ctx context.Context, module api.Module, params []uint6
 	if err != nil {
 		return
 	}
-	module.Memory().Write(ctx, uint32(writeBuffer[0]), ctxBuffer)
+	module.Memory().Write(uint32(writeBuffer[0]), ctxBuffer)
 
 	return
 }


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) which notably
* Better supports WASI including third-party integrated tests
* Adds support for writeable filesystems via FSConfig
* Improves observability with LogScopes, e.g. filesystem.
* Obviates Namespace in favor of cheaper Runtimes sharing a CompilationCache

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
