### PR TITLE
Tiny fix quick-start.mdx for how to define port

### DIFF
--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -223,10 +223,10 @@ scale run hello-world:latest
 ```
 
 This will start a local HTTP server on port `8080` and will run the function whenever you make a request to it. You can
-also specify a different port by passing the `--port` or `-p` flag:
+also specify a different port by passing the `--listen` or `-l` flag:
 
 ```bash
-scale run hello-world:latest -p 3000
+scale run hello-world:latest -l :3000
 ```
 
 <Note>


### PR DESCRIPTION
Hi, I just found out that the `scale run ` has no -p flag and only have the -listen or -l flag. So this seems to be a doc error.