### PR TITLE
Jm/js module linking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,11 @@ jobs:
         name: jsbuilder-x86_64-windows.gz
         path: releases/
 
+    - uses: actions/download-artifact@v3
+      with:
+        name: jslinksource_engine
+        path: releases/
+
     - name: Create version file
       run: echo ${{ github.event.release.tag_name }} > releases/jsbuilder-version.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,42 @@ on:
       - published
 
 jobs:
+  compile_jslinksource:
+    name: compile_jslinksource
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install target
+        run: rustup target add wasm32-wasi
+
+      - name: Install wasi-sdk
+        working-directory: ts/compile/builder
+        run: make download-wasi-sdk
+
+      - name: Install wizer
+        working-directory: ts/compile/builder
+        run: cargo install wizer --all-features
+
+      - name: Make jslinksource
+        working-directory: ts/compile/builder
+        run: make jslinksource
+      
+      - name: Copy wasm
+        run: cp ts/compile/builder/crates/core/target_jslinksource/wasm32-wasi/release/jsbuilder_core.wasm jslinksource.wasm
+
+      - name: Upload core binary to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: jslinksource_engine
+          path: jslinksource.wasm
+
+      - name: Upload assets to release
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} jslinksource.wasm
+
   compile_core:
     name: compile_core
     runs-on: macos-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopholelabs/scale",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Scale is a highly-performant WebAssembly function runtime that enables composable, language-agnostic software development.",
   "source": "ts/index.ts",
   "types": "types.d.ts",

--- a/ts/compile/builder/Makefile
+++ b/ts/compile/builder/Makefile
@@ -23,6 +23,11 @@ jssource:
 				&& cargo build --release --target=wasm32-wasi --no-default-features --features js_source --target-dir target_jssource \
 				&& cd -
 
+jslinksource:
+		cd crates/core \
+				&& cargo build --release --target=wasm32-wasi --no-default-features --features js_link_source --target-dir target_jslinksource \
+				&& cd -
+
 clean: clean-wasi-sdk clean-cargo
 
 clean-cargo:

--- a/ts/compile/builder/crates/core/Cargo.toml
+++ b/ts/compile/builder/crates/core/Cargo.toml
@@ -18,3 +18,4 @@ flate2 = "1.0.25"
 default = ["wizer_opt"]
 wizer_opt = []
 js_source = []
+js_link_source = []


### PR DESCRIPTION
This adds an extra option to jsbuilder - providing the source from the host.
This also allows for module linking etc.
There are two imported functions
get_source_len -> i32
get_source(ptr: i32) -> i32 (Should return 1 if the source is gzipped, else 0).