### PR TITLE
Fix: Converter not handing multiple embedded models correctly

### DIFF
--- a/signature/converter/converter.go
+++ b/signature/converter/converter.go
@@ -73,7 +73,6 @@ func New(schema *signature.Schema) (*Converter, error) {
 		p.models[model.Name] = model
 		if model.Name == p.ctxName {
 			p.ctxModel = model
-			break
 		}
 	}
 	if p.ctxModel == nil {

--- a/signature/converter/converter_test.go
+++ b/signature/converter/converter_test.go
@@ -1,3 +1,5 @@
+//go:build !integration && !generate
+
 /*
 	Copyright 2023 Loophole Labs
 	Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR fixes a minor bug where the converter would not handle decoding structs where there were multiple embedded models due to an early break condition in an important loop. 