### PR TITLE
Fix: TypeScript Host Import Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixes
+
+- Added an `index.ts` file to the `scalefunc` and `log` packages in TypeScript to make importing them more ergonomic
+
 ## [v0.4.5] - 2023-10-09
 
 ### Features

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -14,7 +14,7 @@
         limitations under the License.
 */
 
-import { ScaleFunc } from "../scalefunc/scalefunc";
+import { ScaleFunc } from "../scalefunc";
 import { New as NewScale } from "../scale";
 
 import fs from "fs";

--- a/log/index.ts
+++ b/log/index.ts
@@ -1,5 +1,5 @@
 /*
-	Copyright 2023 Loophole Labs
+	Copyright 2022 Loophole Labs
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
 	limitations under the License.
 */
 
-import {Writer} from "scale";
-
-export function NamedLogger(name: string, writer: Writer): Writer {
-    return (message: string) => {
-        writer(`${name}: ${message}`);
-    }
-}
+export * from "./log";

--- a/module.ts
+++ b/module.ts
@@ -21,7 +21,7 @@ import {UnpackUint32} from "./utils";
 import {Decoder} from "@loopholelabs/polyglot";
 import {DisabledWASI} from "./wasi";
 import {v4 as uuid} from "uuid";
-import {NamedLogger} from "./log/log";
+import {NamedLogger} from "./log";
 import {Tracing} from "./tracing";
 
 export async function NewModule<T extends Signature>(template: Template<T>): Promise<Module<T>> {

--- a/scalefunc/index.ts
+++ b/scalefunc/index.ts
@@ -1,5 +1,5 @@
 /*
-	Copyright 2023 Loophole Labs
+	Copyright 2022 Loophole Labs
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
 	limitations under the License.
 */
 
-import {Writer} from "scale";
-
-export function NamedLogger(name: string, writer: Writer): Writer {
-    return (message: string) => {
-        writer(`${name}: ${message}`);
-    }
-}
+export * from "./scalefunc";


### PR DESCRIPTION
When we currently import the scalefunc package from the Scale Typescript module, we do so via @loopholelabs/scale/scalefunc/scalefunc . This can be rectified with a simple index.ts file in the scalefunc folder.

This PR fixes this issue completely, and fixes it for the `@loopholelabs/scale/log/log` package as well. 