### PR TITLE
docs: fix copy paste error

### DIFF
--- a/docs/languages/golang/adapters/net-http.mdx
+++ b/docs/languages/golang/adapters/net-http.mdx
@@ -88,7 +88,7 @@ the Scale Function into our Golang application.
     Scale Functions.
 </Tip>
 
-To import the Scale Function into our Next.js App, it's as simple as using the native `import` statement:
+To import the Scale Function into our Golang App, it's as simple as using the native `import` statement:
 ```go main.go
 package main
 


### PR DESCRIPTION
The embedding part was seemingly copy pasted from the js/ts docs, and left without changiung the language reference.